### PR TITLE
Fix installation with recent git installed.

### DIFF
--- a/configure
+++ b/configure
@@ -27,7 +27,7 @@ return 0
 }
 
 # Check if repository is dirty.
-CLEAN=$(git status | grep "working directory clean")
+CLEAN=$(git status | grep "clean")
 if [ -z "$CLEAN" ]; then
    echo "\nGit repository is dirty."
    echo "Commit or clean changes before install.\n"


### PR DESCRIPTION
Hi @gui11aume, I had some problems installing HMMt with a recent git installed,
this PR should fix it.

If the working dir is clean git now prints `nothing to commit, working tree clean`.
To accomodate both old and new git (in my case 2.16.2) I've reduced the grep to
`clean`.

On a side note, would you still recommend this package for DamID(seq) data, or is there something newer out there ? That said preliminary results look reasonable, so thanks for proving the package!